### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/fake_filesystem_glob_test.py
+++ b/fake_filesystem_glob_test.py
@@ -34,9 +34,9 @@ class FakeGlobUnitTest(unittest.TestCase):
     self.glob = fake_filesystem_glob.FakeGlobModule(self.filesystem)
     directory = './xyzzy'
     self.filesystem.CreateDirectory(directory)
-    self.filesystem.CreateDirectory('%s/subdir' % directory)
-    self.filesystem.CreateDirectory('%s/subdir2' % directory)
-    self.filesystem.CreateFile('%s/subfile' % directory)
+    self.filesystem.CreateDirectory('{0!s}/subdir'.format(directory))
+    self.filesystem.CreateDirectory('{0!s}/subdir2'.format(directory))
+    self.filesystem.CreateFile('{0!s}/subfile'.format(directory))
     self.filesystem.CreateFile('[Temp]')
 
   def testGlobEmpty(self):

--- a/fake_filesystem_shutil_test.py
+++ b/fake_filesystem_shutil_test.py
@@ -37,8 +37,8 @@ class FakeShutilModuleTest(unittest.TestCase):
   def testRmtree(self):
     directory = 'xyzzy'
     self.filesystem.CreateDirectory(directory)
-    self.filesystem.CreateDirectory('%s/subdir' % directory)
-    self.filesystem.CreateFile('%s/subfile' % directory)
+    self.filesystem.CreateDirectory('{0!s}/subdir'.format(directory))
+    self.filesystem.CreateFile('{0!s}/subfile'.format(directory))
     self.assertTrue(self.filesystem.Exists(directory))
     self.shutil.rmtree(directory)
     self.assertFalse(self.filesystem.Exists(directory))
@@ -58,7 +58,7 @@ class FakeShutilModuleTest(unittest.TestCase):
   def testCopyDirectory(self):
     src_file = 'xyzzy'
     parent_directory = 'parent'
-    dst_file = '%s/%s' % (parent_directory, src_file)
+    dst_file = '{0!s}/{1!s}'.format(parent_directory, src_file)
     src_obj = self.filesystem.CreateFile(src_file)
     self.filesystem.CreateDirectory(parent_directory)
     src_obj.st_mode = ((src_obj.st_mode & ~0o7777) | 0o750)
@@ -112,7 +112,7 @@ class FakeShutilModuleTest(unittest.TestCase):
   def testCopy2Directory(self):
     src_file = 'xyzzy'
     parent_directory = 'parent'
-    dst_file = '%s/%s' % (parent_directory, src_file)
+    dst_file = '{0!s}/{1!s}'.format(parent_directory, src_file)
     src_obj = self.filesystem.CreateFile(src_file)
     self.filesystem.CreateDirectory(parent_directory)
     src_obj.st_mode = ((src_obj.st_mode & ~0o7777) | 0o750)
@@ -136,14 +136,14 @@ class FakeShutilModuleTest(unittest.TestCase):
     src_directory = 'xyzzy'
     dst_directory = 'xyzzy_copy'
     self.filesystem.CreateDirectory(src_directory)
-    self.filesystem.CreateDirectory('%s/subdir' % src_directory)
-    self.filesystem.CreateFile('%s/subfile' % src_directory)
+    self.filesystem.CreateDirectory('{0!s}/subdir'.format(src_directory))
+    self.filesystem.CreateFile('{0!s}/subfile'.format(src_directory))
     self.assertTrue(self.filesystem.Exists(src_directory))
     self.assertFalse(self.filesystem.Exists(dst_directory))
     self.shutil.copytree(src_directory, dst_directory)
     self.assertTrue(self.filesystem.Exists(dst_directory))
-    self.assertTrue(self.filesystem.Exists('%s/subdir' % dst_directory))
-    self.assertTrue(self.filesystem.Exists('%s/subfile' % dst_directory))
+    self.assertTrue(self.filesystem.Exists('{0!s}/subdir'.format(dst_directory)))
+    self.assertTrue(self.filesystem.Exists('{0!s}/subfile'.format(dst_directory)))
 
   def testCopytreeSrcIsFile(self):
     src_file = 'xyzzy'
@@ -169,7 +169,7 @@ class FakeShutilModuleTest(unittest.TestCase):
   def testMoveFileIntoDirectory(self):
     src_file = 'xyzzy'
     dst_directory = 'directory'
-    dst_file = '%s/%s' % (dst_directory, src_file)
+    dst_file = '{0!s}/{1!s}'.format(dst_directory, src_file)
     self.filesystem.CreateFile(src_file)
     self.filesystem.CreateDirectory(dst_directory)
     self.assertTrue(self.filesystem.Exists(src_file))
@@ -182,14 +182,14 @@ class FakeShutilModuleTest(unittest.TestCase):
     src_directory = 'original_xyzzy'
     dst_directory = 'moved_xyzzy'
     self.filesystem.CreateDirectory(src_directory)
-    self.filesystem.CreateFile('%s/subfile' % src_directory)
-    self.filesystem.CreateDirectory('%s/subdir' % src_directory)
+    self.filesystem.CreateFile('{0!s}/subfile'.format(src_directory))
+    self.filesystem.CreateDirectory('{0!s}/subdir'.format(src_directory))
     self.assertTrue(self.filesystem.Exists(src_directory))
     self.assertFalse(self.filesystem.Exists(dst_directory))
     self.shutil.move(src_directory, dst_directory)
     self.assertTrue(self.filesystem.Exists(dst_directory))
-    self.assertTrue(self.filesystem.Exists('%s/subfile' % dst_directory))
-    self.assertTrue(self.filesystem.Exists('%s/subdir' % dst_directory))
+    self.assertTrue(self.filesystem.Exists('{0!s}/subfile'.format(dst_directory)))
+    self.assertTrue(self.filesystem.Exists('{0!s}/subdir'.format(dst_directory)))
     self.assertFalse(self.filesystem.Exists(src_directory))
 
 
@@ -259,7 +259,7 @@ class CopyFileTest(unittest.TestCase):
   def testRaisesIfDestDirIsNotWritable(self):
     src_file = 'xyzzy'
     dst_dir = '/tmp/foo'
-    dst_file = '%s/%s' % (dst_dir, src_file)
+    dst_file = '{0!s}/{1!s}'.format(dst_dir, src_file)
     src_contents = 'contents of source file'
     self.filesystem.CreateFile(src_file, contents=src_contents)
     self.filesystem.CreateDirectory(dst_dir, perm_bits=0o555)

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -335,7 +335,7 @@ class FakeFilesystemUnitTest(TestCase):
     self.assertRaises(
         IOError, self.filesystem.RemoveObject,
         self.filesystem.JoinPaths(
-            '%s' % self.fake_file.name,
+            '{0!s}'.format(self.fake_file.name),
             'file_does_not_matter_since_parent_not_a_directory'))
 
   def testExistsFileRemovedFromChild(self):
@@ -382,7 +382,7 @@ class FakeFilesystemUnitTest(TestCase):
     self.assertTrue(stat.S_IFDIR & new_dir.st_mode)
 
     # Create second directory to make sure first is OK.
-    path = '%s/quux' % path
+    path = '{0!s}/quux'.format(path)
     self.filesystem.CreateDirectory(path)
     new_dir = self.filesystem.GetObject(path)
     self.assertEqual(os.path.basename(path), new_dir.name)
@@ -399,7 +399,7 @@ class FakeFilesystemUnitTest(TestCase):
     self.filesystem.CreateFile(path, contents=contents)
     self.assertTrue(self.filesystem.Exists(path))
     self.assertFalse(self.filesystem.Exists(os.path.dirname(path)))
-    path = './%s' % path
+    path = './{0!s}'.format(path)
     self.assertTrue(self.filesystem.Exists(os.path.dirname(path)))
 
   def testCreateFileInRootDirectory(self):
@@ -519,7 +519,7 @@ class FakeOsModuleTest(TestCase):
         expected_regexp = re.compile(expected_regexp)
       self.assertTrue(
           expected_regexp.search(str(err)),
-          '"%s" does not match "%s"' % (expected_regexp.pattern, str(err)))
+          '"{0!s}" does not match "{1!s}"'.format(expected_regexp.pattern, str(err)))
     else:
       self.fail(expected_exception.__name__ + ' not raised')
 
@@ -574,7 +574,7 @@ class FakeOsModuleTest(TestCase):
     directory = 'xyzzy/plugh'
     files = ['foo', 'bar', 'baz']
     for f in files:
-      self.filesystem.CreateFile('%s/%s' % (directory, f))
+      self.filesystem.CreateFile('{0!s}/{1!s}'.format(directory, f))
     files.sort()
     self.assertEqual(files, self.os.listdir(directory))
 
@@ -582,7 +582,7 @@ class FakeOsModuleTest(TestCase):
     directory = 'xyzzy'
     files = ['foo', 'bar', 'baz']
     for f in files:
-      self.filesystem.CreateFile('%s/%s' % (directory, f))
+      self.filesystem.CreateFile('{0!s}/{1!s}'.format(directory, f))
     self.filesystem.CreateLink('symlink', 'xyzzy')
     files.sort()
     self.assertEqual(files, self.os.listdir('symlink'))
@@ -598,7 +598,7 @@ class FakeOsModuleTest(TestCase):
   def testListdirCurrent(self):
     files = ['foo', 'bar', 'baz']
     for f in files:
-      self.filesystem.CreateFile('%s' % f)
+      self.filesystem.CreateFile('{0!s}'.format(f))
     files.sort()
     self.assertEqual(files, self.os.listdir('.'))
 
@@ -704,7 +704,7 @@ class FakeOsModuleTest(TestCase):
 
   def testFstat(self):
     directory = 'xyzzy'
-    file_path = '%s/plugh' % directory
+    file_path = '{0!s}/plugh'.format(directory)
     self.filesystem.CreateFile(file_path, contents='ABCDE')
     fake_open = fake_filesystem.FakeFileOpen(self.filesystem)
     file_obj = fake_open(file_path)
@@ -715,7 +715,7 @@ class FakeOsModuleTest(TestCase):
 
   def testStat(self):
     directory = 'xyzzy'
-    file_path = '%s/plugh' % directory
+    file_path = '{0!s}/plugh'.format(directory)
     self.filesystem.CreateFile(file_path, contents='ABCDE')
     self.assertTrue(stat.S_IFDIR & self.os.stat(directory)[stat.ST_MODE])
     self.assertTrue(stat.S_IFREG & self.os.stat(file_path)[stat.ST_MODE])
@@ -728,8 +728,8 @@ class FakeOsModuleTest(TestCase):
     file_contents = 'frobozz'
     # Just make sure we didn't accidentally make our test data meaningless.
     self.assertNotEqual(len(base_name), len(file_contents))
-    file_path = '%s/%s' % (directory, base_name)
-    link_path = '%s/link' % directory
+    file_path = '{0!s}/{1!s}'.format(directory, base_name)
+    link_path = '{0!s}/link'.format(directory)
     self.filesystem.CreateFile(file_path, contents=file_contents)
     self.filesystem.CreateLink(link_path, base_name)
     self.assertEqual(len(file_contents), self.os.lstat(file_path)[stat.ST_SIZE])
@@ -778,7 +778,7 @@ class FakeOsModuleTest(TestCase):
 
   def testRemoveDir(self):
     directory = 'xyzzy'
-    dir_path = '/%s/plugh' % directory
+    dir_path = '/{0!s}/plugh'.format(directory)
     self.filesystem.CreateDirectory(dir_path)
     self.assertTrue(self.filesystem.Exists(dir_path))
     self.assertRaises(OSError, self.os.remove, dir_path)
@@ -790,7 +790,7 @@ class FakeOsModuleTest(TestCase):
 
   def testRemoveFile(self):
     directory = 'zzy'
-    file_path = '%s/plugh' % directory
+    file_path = '{0!s}/plugh'.format(directory)
     self.filesystem.CreateFile(file_path)
     self.assertTrue(self.filesystem.Exists(file_path))
     self.os.remove(file_path)
@@ -799,7 +799,7 @@ class FakeOsModuleTest(TestCase):
   def testRemoveFileNoDirectory(self):
     directory = 'zzy'
     file_name = 'plugh'
-    file_path = '%s/%s' % (directory, file_name)
+    file_path = '{0!s}/{1!s}'.format(directory, file_name)
     self.filesystem.CreateFile(file_path)
     self.assertTrue(self.filesystem.Exists(file_path))
     self.os.chdir(directory)
@@ -811,7 +811,7 @@ class FakeOsModuleTest(TestCase):
     directory = 'zzy'
     subdirectory = self.os.path.join(directory, directory)
     file_name = 'plugh'
-    file_path = '%s/%s' % (directory, file_name)
+    file_path = '{0!s}/{1!s}'.format(directory, file_name)
     file_path_relative = self.os.path.join('..', file_name)
     self.filesystem.CreateFile(file_path)
     self.assertTrue(self.filesystem.Exists(file_path))
@@ -852,8 +852,8 @@ class FakeOsModuleTest(TestCase):
   def testRenameToNonexistentFile(self):
     """Can rename a file to an unused name."""
     directory = 'xyzzy'
-    old_file_path = '%s/plugh_old' % directory
-    new_file_path = '%s/plugh_new' % directory
+    old_file_path = '{0!s}/plugh_old'.format(directory)
+    new_file_path = '{0!s}/plugh_new'.format(directory)
     self.filesystem.CreateFile(old_file_path, contents='test contents')
     self.assertTrue(self.filesystem.Exists(old_file_path))
     self.assertFalse(self.filesystem.Exists(new_file_path))
@@ -866,20 +866,20 @@ class FakeOsModuleTest(TestCase):
   def testRenameDirectory(self):
     """Can rename a directory to an unused name."""
     for old_path, new_path in [('wxyyw', 'xyzzy'), ('/abccb', 'cdeed')]:
-      self.filesystem.CreateFile('%s/plugh' % old_path, contents='test')
+      self.filesystem.CreateFile('{0!s}/plugh'.format(old_path), contents='test')
       self.assertTrue(self.filesystem.Exists(old_path))
       self.assertFalse(self.filesystem.Exists(new_path))
       self.os.rename(old_path, new_path)
       self.assertFalse(self.filesystem.Exists(old_path))
       self.assertTrue(self.filesystem.Exists(new_path))
       self.assertEqual(
-          'test', self.filesystem.GetObject('%s/plugh' % new_path).contents)
+          'test', self.filesystem.GetObject('{0!s}/plugh'.format(new_path)).contents)
 
   def testRenameToExistentFile(self):
     """Can rename a file to a used name."""
     directory = 'xyzzy'
-    old_file_path = '%s/plugh_old' % directory
-    new_file_path = '%s/plugh_new' % directory
+    old_file_path = '{0!s}/plugh_old'.format(directory)
+    new_file_path = '{0!s}/plugh_new'.format(directory)
     self.filesystem.CreateFile(old_file_path, contents='test contents 1')
     self.filesystem.CreateFile(new_file_path, contents='test contents 2')
     self.assertTrue(self.filesystem.Exists(old_file_path))
@@ -893,8 +893,8 @@ class FakeOsModuleTest(TestCase):
   def testRenameToNonexistentDir(self):
     """Can rename a file to a name in a nonexistent dir."""
     directory = 'xyzzy'
-    old_file_path = '%s/plugh_old' % directory
-    new_file_path = '%s/no_such_path/plugh_new' % directory
+    old_file_path = '{0!s}/plugh_old'.format(directory)
+    new_file_path = '{0!s}/no_such_path/plugh_new'.format(directory)
     self.filesystem.CreateFile(old_file_path, contents='test contents')
     self.assertTrue(self.filesystem.Exists(old_file_path))
     self.assertFalse(self.filesystem.Exists(new_file_path))
@@ -914,22 +914,22 @@ class FakeOsModuleTest(TestCase):
   def testRenameEmptyDir(self):
     """Test a rename of an empty directory."""
     directory = 'xyzzy'
-    before_dir = '%s/empty' % directory
-    after_dir = '%s/unused' % directory
+    before_dir = '{0!s}/empty'.format(directory)
+    after_dir = '{0!s}/unused'.format(directory)
     self.filesystem.CreateDirectory(before_dir)
-    self.assertTrue(self.filesystem.Exists('%s/.' % before_dir))
+    self.assertTrue(self.filesystem.Exists('{0!s}/.'.format(before_dir)))
     self.assertFalse(self.filesystem.Exists(after_dir))
     self.os.rename(before_dir, after_dir)
     self.assertFalse(self.filesystem.Exists(before_dir))
-    self.assertTrue(self.filesystem.Exists('%s/.' % after_dir))
+    self.assertTrue(self.filesystem.Exists('{0!s}/.'.format(after_dir)))
 
   def testRenameDir(self):
     """Test a rename of a directory."""
     directory = 'xyzzy'
-    before_dir = '%s/before' % directory
-    before_file = '%s/before/file' % directory
-    after_dir = '%s/after' % directory
-    after_file = '%s/after/file' % directory
+    before_dir = '{0!s}/before'.format(directory)
+    before_file = '{0!s}/before/file'.format(directory)
+    after_dir = '{0!s}/after'.format(directory)
+    after_file = '{0!s}/after/file'.format(directory)
     self.filesystem.CreateDirectory(before_dir)
     self.filesystem.CreateFile(before_file, contents='payload')
     self.assertTrue(self.filesystem.Exists(before_dir))
@@ -947,8 +947,8 @@ class FakeOsModuleTest(TestCase):
   def testRenamePreservesStat(self):
     """Test if rename preserves mtime."""
     directory = 'xyzzy'
-    old_file_path = '%s/plugh_old' % directory
-    new_file_path = '%s/plugh_new' % directory
+    old_file_path = '{0!s}/plugh_old'.format(directory)
+    new_file_path = '{0!s}/plugh_new'.format(directory)
     old_file = self.filesystem.CreateFile(old_file_path)
     old_file.SetMTime(old_file.st_mtime - 3600)
     self.os.chown(old_file_path, 200, 200)
@@ -966,7 +966,7 @@ class FakeOsModuleTest(TestCase):
     """Test renaming when old and new names are the same."""
     directory = 'xyzzy'
     file_contents = 'Spam eggs'
-    file_path = '%s/eggs' % directory
+    file_path = '{0!s}/eggs'.format(directory)
     self.filesystem.CreateFile(file_path, contents=file_contents)
     self.os.rename(file_path, file_path)
     self.assertEqual(file_contents,
@@ -993,7 +993,7 @@ class FakeOsModuleTest(TestCase):
   def testRmdirRaisesIfNotEmpty(self):
     """Raises an exception if the target directory is not empty."""
     directory = 'xyzzy'
-    file_path = '%s/plugh' % directory
+    file_path = '{0!s}/plugh'.format(directory)
     self.filesystem.CreateFile(file_path)
     self.assertTrue(self.filesystem.Exists(file_path))
     self.assertRaises(OSError, self.os.rmdir, directory)
@@ -1001,7 +1001,7 @@ class FakeOsModuleTest(TestCase):
   def testRmdirRaisesIfNotDirectory(self):
     """Raises an exception if the target is not a directory."""
     directory = 'xyzzy'
-    file_path = '%s/plugh' % directory
+    file_path = '{0!s}/plugh'.format(directory)
     self.filesystem.CreateFile(file_path)
     self.assertTrue(self.filesystem.Exists(file_path))
     self.assertRaises(OSError, self.os.rmdir, file_path)
@@ -1080,13 +1080,13 @@ class FakeOsModuleTest(TestCase):
     directory = 'xyzzy'
     self.assertFalse(self.filesystem.Exists(directory))
     self.os.mkdir(directory)
-    self.assertTrue(self.filesystem.Exists('/%s' % directory))
+    self.assertTrue(self.filesystem.Exists('/{0!s}'.format(directory)))
     self.os.chdir(directory)
     self.os.mkdir(directory)
-    self.assertTrue(self.filesystem.Exists('/%s/%s' % (directory, directory)))
+    self.assertTrue(self.filesystem.Exists('/{0!s}/{1!s}'.format(directory, directory)))
     self.os.chdir(directory)
     self.os.mkdir('../abccb')
-    self.assertTrue(self.filesystem.Exists('/%s/abccb' % directory))
+    self.assertTrue(self.filesystem.Exists('/{0!s}/abccb'.format(directory)))
 
   def testMkdirWithTrailingSlash(self):
     """mkdir can create a directory named with a trailing slash."""
@@ -1104,7 +1104,7 @@ class FakeOsModuleTest(TestCase):
   def testMkdirRaisesIfNoParent(self):
     """mkdir raises exception if parent directory does not exist."""
     parent = 'xyzzy'
-    directory = '%s/foo' % (parent,)
+    directory = '{0!s}/foo'.format(parent)
     self.assertFalse(self.filesystem.Exists(parent))
     self.assertRaises(Exception, self.os.mkdir, directory)
 
@@ -1118,7 +1118,7 @@ class FakeOsModuleTest(TestCase):
   def testMkdirRaisesIfFileExists(self):
     """mkdir raises exception if name already exists as a file."""
     directory = 'xyzzy'
-    file_path = '%s/plugh' % directory
+    file_path = '{0!s}/plugh'.format(directory)
     self.filesystem.CreateFile(file_path)
     self.assertTrue(self.filesystem.Exists(file_path))
     self.assertRaises(Exception, self.os.mkdir, file_path)
@@ -1160,7 +1160,7 @@ class FakeOsModuleTest(TestCase):
   def testMakedirs(self):
     """makedirs can create a directory even in parent does not exist."""
     parent = 'xyzzy'
-    directory = '%s/foo' % (parent,)
+    directory = '{0!s}/foo'.format(parent)
     self.assertFalse(self.filesystem.Exists(parent))
     self.os.makedirs(directory)
     self.assertTrue(self.filesystem.Exists(parent))
@@ -1168,7 +1168,7 @@ class FakeOsModuleTest(TestCase):
   def testMakedirsRaisesIfParentIsFile(self):
     """makedirs raises exception if a parent component exists as a file."""
     file_path = 'xyzzy'
-    directory = '%s/plugh' % file_path
+    directory = '{0!s}/plugh'.format(file_path)
     self.filesystem.CreateFile(file_path)
     self.assertTrue(self.filesystem.Exists(file_path))
     self.assertRaises(Exception, self.os.makedirs, directory)
@@ -1500,7 +1500,7 @@ class FakeOsModuleTest(TestCase):
 
   def testMkNodeRaisesIfParentDirDoesntExist(self):
     parent = 'xyzzy'
-    filename = '%s/foo' % (parent,)
+    filename = '{0!s}/foo'.format(parent)
     self.assertFalse(self.filesystem.Exists(parent))
     self.assertRaises(OSError, self.os.mknod, filename)
 
@@ -1584,11 +1584,11 @@ class FakeOsModuleTest(TestCase):
     root = '/foo'
     visit = 'visit'
     no_visit = 'no_visit'
-    self.filesystem.CreateFile('%s/bar' % (root,))
-    self.filesystem.CreateFile('%s/%s/1.txt' % (root, visit))
-    self.filesystem.CreateFile('%s/%s/2.txt' % (root, visit))
-    self.filesystem.CreateFile('%s/%s/3.txt' % (root, no_visit))
-    self.filesystem.CreateFile('%s/%s/4.txt' % (root, no_visit))
+    self.filesystem.CreateFile('{0!s}/bar'.format(root))
+    self.filesystem.CreateFile('{0!s}/{1!s}/1.txt'.format(root, visit))
+    self.filesystem.CreateFile('{0!s}/{1!s}/2.txt'.format(root, visit))
+    self.filesystem.CreateFile('{0!s}/{1!s}/3.txt'.format(root, no_visit))
+    self.filesystem.CreateFile('{0!s}/{1!s}/4.txt'.format(root, no_visit))
 
     generator = self.os.walk('/foo')
     root_contents = next(generator)
@@ -1597,8 +1597,8 @@ class FakeOsModuleTest(TestCase):
     visited_visit_directory = False
 
     for root, unused_dirs, unused_files in iter(generator):
-      self.assertEqual(False, root.endswith('/%s' % (no_visit)))
-      if root.endswith('/%s' % (visit)):
+      self.assertEqual(False, root.endswith('/{0!s}'.format((no_visit))))
+      if root.endswith('/{0!s}'.format((visit))):
         visited_visit_directory = True
 
     self.assertEqual(True, visited_visit_directory)
@@ -1786,11 +1786,11 @@ class OsPathInjectionRegressionTest(TestCase):
     self.filesystem.CreateDirectory(top_level_dir)
     self.assertTrue(self.filesystem.Exists('/'))
     self.assertTrue(self.filesystem.Exists(top_level_dir))
-    self.filesystem.CreateDirectory('%s/po' % top_level_dir)
-    self.filesystem.CreateFile('%s/po/control' % top_level_dir)
-    self.filesystem.CreateFile('%s/po/experiment' % top_level_dir)
-    self.filesystem.CreateDirectory('%s/gv' % top_level_dir)
-    self.filesystem.CreateFile('%s/gv/control' % top_level_dir)
+    self.filesystem.CreateDirectory('{0!s}/po'.format(top_level_dir))
+    self.filesystem.CreateFile('{0!s}/po/control'.format(top_level_dir))
+    self.filesystem.CreateFile('{0!s}/po/experiment'.format(top_level_dir))
+    self.filesystem.CreateDirectory('{0!s}/gv'.format(top_level_dir))
+    self.filesystem.CreateFile('{0!s}/gv/control'.format(top_level_dir))
 
     expected = [
         ('/', ['x'], []),
@@ -1815,11 +1815,11 @@ class FakePathModuleTest(TestCase):
   def testAbspath(self):
     """abspath should return a consistent representation of a file."""
     filename = 'foo'
-    abspath = '/%s' % filename
+    abspath = '/{0!s}'.format(filename)
     self.filesystem.CreateFile(abspath)
     self.assertEqual(abspath, self.path.abspath(abspath))
     self.assertEqual(abspath, self.path.abspath(filename))
-    self.assertEqual(abspath, self.path.abspath('../%s' % filename))
+    self.assertEqual(abspath, self.path.abspath('../{0!s}'.format(filename)))
 
   def testAbspathDealsWithRelativeNonRootPath(self):
     """abspath should correctly handle relative paths from a non-/ directory.
@@ -1829,7 +1829,7 @@ class FakePathModuleTest(TestCase):
     """
     filename = '/foo/bar/baz'
     file_components = filename.split(self.path.sep)
-    basedir = '/%s' % (file_components[0],)
+    basedir = '/{0!s}'.format(file_components[0])
     self.filesystem.CreateFile(filename)
     self.os.chdir(basedir)
     self.assertEqual(basedir, self.path.abspath(self.path.curdir))
@@ -1851,7 +1851,7 @@ class FakePathModuleTest(TestCase):
         self.assertEqual('path/to/foo', self.path.relpath(path_foo))
     self.assertEqual('../foo',
                      self.path.relpath(path_foo, path_bar))
-    self.assertEqual('../../..%s' % path_other,
+    self.assertEqual('../../..{0!s}'.format(path_other),
                      self.path.relpath(path_other, path_bar))
     self.assertEqual('.',
                      self.path.relpath(path_bar, path_bar))
@@ -1885,7 +1885,7 @@ class FakePathModuleTest(TestCase):
 
   def testDirname(self):
     dirname = 'foo/bar'
-    self.assertEqual(dirname, self.path.dirname('%s/baz' % dirname))
+    self.assertEqual(dirname, self.path.dirname('{0!s}/baz'.format(dirname)))
 
   def testJoin(self):
     components = ['foo', 'bar', 'baz']
@@ -1924,7 +1924,7 @@ class FakePathModuleTest(TestCase):
     self.filesystem.CreateDirectory(dir_path)
     size = self.path.getsize(dir_path)
     self.assertFalse(int(size) < 0,
-                     'expected non-negative size; actual: %s' % size)
+                     'expected non-negative size; actual: {0!s}'.format(size))
 
   def testGetsizeDirNonZeroSize(self):
     # For directories, only require that the size is non-negative.
@@ -1932,7 +1932,7 @@ class FakePathModuleTest(TestCase):
     self.filesystem.CreateFile(self.filesystem.JoinPaths(dir_path, 'baz'))
     size = self.path.getsize(dir_path)
     self.assertFalse(int(size) < 0,
-                     'expected non-negative size; actual: %s' % size)
+                     'expected non-negative size; actual: {0!s}'.format(size))
 
   def testIsdir(self):
     self.filesystem.CreateFile('foo/bar')

--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -103,7 +103,7 @@ class TestPyfakefsUnittest(fake_filesystem_unittest.TestCase): # pylint: disable
     def test_tempdirectory(self):
         '''Fake TemporaryDirectory class is bound'''
         with tempfile.TemporaryDirectory() as td:
-            with open('%s/fake_file.txt' % td, 'w') as f:
+            with open('{0!s}/fake_file.txt'.format(td), 'w') as f:
                 self.assertTrue(self.fs.Exists(td))
 
 

--- a/fake_filesystem_vs_real_test.py
+++ b/fake_filesystem_vs_real_test.py
@@ -96,7 +96,7 @@ class FakeFilesystemVsRealTest(TestCase):
         # Base paths in the real and test file systems.     We keep them different
         # so that missing features in the fake don't fall through to the base
         # operations and magically succeed.
-        tsname = 'fakefs.%s' % time.time()
+        tsname = 'fakefs.{0!s}'.format(time.time())
         # Fully expand the base_path - required on OS X.
         self.real_base = os.path.realpath(
                 os.path.join(tempfile.gettempdir(), tsname))
@@ -132,7 +132,7 @@ class FakeFilesystemVsRealTest(TestCase):
                         os.rmdir(real_path)
                     except OSError as e:
                         if 'Directory not empty' in e:
-                            self.fail('Real path %s not empty: %s : %s' % (
+                            self.fail('Real path {0!s} not empty: {1!s} : {2!s}'.format(
                                     real_path, e, os.listdir(real_path)))
                         else:
                             raise
@@ -180,8 +180,8 @@ class FakeFilesystemVsRealTest(TestCase):
         fake_value = None
         real_err = None
         fake_err = None
-        method_call = '%s' % method_name
-        method_call += '()' if path == () else '(%s)' % path
+        method_call = '{0!s}'.format(method_name)
+        method_call += '()' if path == () else '({0!s})'.format(path)
         # Catching Exception below gives a lint warning, but it's what we need.
         try:
             args = [] if path == () else [path]
@@ -203,17 +203,17 @@ class FakeFilesystemVsRealTest(TestCase):
         # is almost always different because of the file paths.
         if _ErrorClass(real_err) != _ErrorClass(fake_err):
             if real_err is None:
-                return '%s: real version returned %s, fake raised %s' % (
+                return '{0!s}: real version returned {1!s}, fake raised {2!s}'.format(
                         method_call, real_value, _ErrorClass(fake_err))
             if fake_err is None:
-                return '%s: real version raised %s, fake returned %s' % (
+                return '{0!s}: real version raised {1!s}, fake returned {2!s}'.format(
                         method_call, _ErrorClass(real_err), fake_value)
-            return '%s: real version raised %s, fake raised %s' % (
+            return '{0!s}: real version raised {1!s}, fake raised {2!s}'.format(
                     method_call, _ErrorClass(real_err), _ErrorClass(fake_err))
         real_errno = self._GetErrno(real_err)
         fake_errno = self._GetErrno(fake_err)
         if real_errno != fake_errno:
-            return '%s(%s): both raised %s, real errno %s, fake errno %s' % (
+            return '{0!s}({1!s}): both raised {2!s}, real errno {3!s}, fake errno {4!s}'.format(
                     method_name, path, _ErrorClass(real_err), real_errno, fake_errno)
         # If the method is supposed to return a full path AND both values
         # begin with the expected full path, then trim it off.
@@ -224,7 +224,7 @@ class FakeFilesystemVsRealTest(TestCase):
                 real_value = real_value[len(self.real_base):]
                 fake_value = fake_value[len(self.fake_base):]
         if real_value != fake_value:
-            return '%s: real return %s, fake returned %s' % (
+            return '{0!s}: real return {1!s}, fake returned {2!s}'.format(
                     method_call, real_value, fake_value)
         return None
 
@@ -351,8 +351,7 @@ class FakeFilesystemVsRealTest(TestCase):
             if diff:
                 differences.append(diff)
         if differences:
-            self.fail('Behaviors do not match for %s:\n    %s' %
-                                (path, '\n    '.join(differences)))
+            self.fail('Behaviors do not match for {0!s}:\n    {1!s}'.format(path, '\n    '.join(differences)))
 
     def assertFileHandleBehaviorsMatch(self, path, mode, data):
         path = Sep(path)
@@ -369,8 +368,7 @@ class FakeFilesystemVsRealTest(TestCase):
             if diff:
                 differences.append(diff)
         if differences:
-            self.fail('Behaviors do not match for %s:\n    %s' %
-                                (path, '\n    '.join(differences)))
+            self.fail('Behaviors do not match for {0!s}:\n    {1!s}'.format(path, '\n    '.join(differences)))
 
     # Helpers for checks which are not straight method calls.
 

--- a/fake_tempfile_test.py
+++ b/fake_tempfile_test.py
@@ -48,7 +48,7 @@ class FakeLogging(object):
     self._message = message
 
   def FailOnMessage(self, message):
-    self._test_case.fail('Unexpected message received: %s' % message)
+    self._test_case.fail('Unexpected message received: {0!s}'.format(message))
 
   warn = FailOnMessage
   info = FailOnMessage

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -269,7 +269,7 @@ class FakeFile(object):
     if st_size < current_size:
       self.contents = self.contents[:st_size]
     else:
-      self.contents = '%s%s' % (self.contents, '\0' * (st_size - current_size))
+      self.contents = '{0!s}{1!s}'.format(self.contents, '\0' * (st_size - current_size))
     self.st_size = len(self.contents)
     self.epoch += 1
 
@@ -290,7 +290,7 @@ class FakeFile(object):
     self.st_mtime = st_mtime
 
   def __str__(self):
-    return '%s(%o)' % (self.name, self.st_mode)
+    return '{0!s}({1:o})'.format(self.name, self.st_mode)
 
   def SetIno(self, st_ino):
     """Set the self.st_ino attribute.
@@ -650,7 +650,7 @@ class FakeFilesystem(object):
     """
 
     def _ComponentsToPath(component_folders):
-      return '%s%s' % (self.path_separator,
+      return '{0!s}{1!s}'.format(self.path_separator,
                        self.path_separator.join(component_folders))
 
     def _ValidRelativePath(file_path):
@@ -703,7 +703,7 @@ class FakeFilesystem(object):
       # file.open('') raises IOError, so mimic that, and validate that all
       # parts of a relative path exist.
       raise IOError(errno.ENOENT,
-                    'No such file or directory: \'%s\'' % file_path)
+                    'No such file or directory: \'{0!s}\''.format(file_path))
     file_path = self.NormalizePath(file_path)
     if file_path == self.root.name:
       return file_path
@@ -734,8 +734,8 @@ class FakeFilesystem(object):
         link_depth += 1
         if link_depth > _MAX_LINK_DEPTH:
           raise IOError(errno.EMLINK,
-                        'Too many levels of symbolic links: \'%s\'' %
-                        _ComponentsToPath(resolved_components))
+                        'Too many levels of symbolic links: \'{0!s}\''.format(
+                        _ComponentsToPath(resolved_components)))
         link_path = _FollowLink(resolved_components, current_dir)
 
         # Following the link might result in the complete replacement of the
@@ -1547,7 +1547,7 @@ class FakeOsModule(object):
     """Removes the FakeFile object representing the specified file."""
     path = self.filesystem.NormalizePath(path)
     if self.path.isdir(path) and not self.path.islink(path):
-      raise OSError(errno.EISDIR, "Is a directory: '%s'" % path)
+      raise OSError(errno.EISDIR, "Is a directory: '{0!s}'".format(path))
     try:
       self.filesystem.RemoveObject(path)
     except IOError as e:
@@ -1835,18 +1835,18 @@ class FakeOsModule(object):
     head, tail = self.path.split(filename)
     if not tail:
       if self.filesystem.Exists(head):
-        raise OSError(errno.EEXIST, 'Fake filesystem: %s: %s' % (
+        raise OSError(errno.EEXIST, 'Fake filesystem: {0!s}: {1!s}'.format(
             os.strerror(errno.EEXIST), filename))
-      raise OSError(errno.ENOENT, 'Fake filesystem: %s: %s' % (
+      raise OSError(errno.ENOENT, 'Fake filesystem: {0!s}: {1!s}'.format(
           os.strerror(errno.ENOENT), filename))
     if tail == '.' or tail == '..' or self.filesystem.Exists(filename):
-      raise OSError(errno.EEXIST, 'Fake fileystem: %s: %s' % (
+      raise OSError(errno.EEXIST, 'Fake fileystem: {0!s}: {1!s}'.format(
           os.strerror(errno.EEXIST), filename))
     try:
       self.filesystem.AddObject(head, FakeFile(tail,
                                                mode & ~self.filesystem.umask))
     except IOError:
-      raise OSError(errno.ENOTDIR, 'Fake filesystem: %s: %s' % (
+      raise OSError(errno.ENOTDIR, 'Fake filesystem: {0!s}: {1!s}'.format(
           os.strerror(errno.ENOTDIR), filename))
 
   def symlink(self, link_target, path):
@@ -2162,7 +2162,7 @@ class FakeFileOpen(object):
     mode = mode.replace('rU', 'r').replace('U', 'r')
 
     if mode not in _OPEN_MODE_MAP:
-      raise IOError('Invalid mode: %r' % orig_modes)
+      raise IOError('Invalid mode: {0!r}'.format(orig_modes))
 
     must_exist, need_read, need_write, truncate, append = _OPEN_MODE_MAP[mode]
 

--- a/pyfakefs/fake_filesystem_shutil.py
+++ b/pyfakefs/fake_filesystem_shutil.py
@@ -120,7 +120,7 @@ class FakeShutilModule(object):
     abspath_dst = self.filesystem.NormalizePath(
         self.filesystem.ResolvePath(dst))
     if abspath_src == abspath_dst:
-      raise shutil.Error('`%s` and `%s` are the same file' % (src, dst))
+      raise shutil.Error('`{0!s}` and `{1!s}` are the same file'.format(src, dst))
 
     if self.filesystem.Exists(dst):
       dst_file_object = self.filesystem.GetObject(dst)
@@ -181,7 +181,7 @@ class FakeShutilModule(object):
       raise OSError(e.errno, e.message)
     if not stat.S_ISDIR(directory.st_mode):
       raise OSError(errno.ENOTDIR,
-                    'Fake os module: %r not a directory' % src)
+                    'Fake os module: {0!r} not a directory'.format(src))
     for name in directory.contents:
       srcname = self.filesystem.JoinPaths(src, name)
       dstname = self.filesystem.JoinPaths(dst, name)

--- a/pyfakefs/fake_tempfile.py
+++ b/pyfakefs/fake_tempfile.py
@@ -76,7 +76,7 @@ class FakeTempfileModule(object):
       prefix = self._temp_prefix
     while not filename or self._filesystem.Exists(filename):
       # pylint: disable-msg=W0212
-      filename = self._filesystem.JoinPaths(dir, '%s%s%s' % (
+      filename = self._filesystem.JoinPaths(dir, '{0!s}{1!s}{2!s}'.format(
           prefix,
           next(self._tempfile._RandomNameSequence()),
           suffix))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pyfakefs?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pyfakefs?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
